### PR TITLE
Fix sensor event generation in the full example

### DIFF
--- a/examples/full/client.rb
+++ b/examples/full/client.rb
@@ -100,8 +100,9 @@ while true
   sensors.shortest_minute_request(request_time)
   sensors.perc90_minute_request(request_time)
 
-  agent_counter = sensors.sensor(agent_names.shuffle.first)
-  agent_counter.event(1)
+  sensors.sensor(agent_names.shuffle.first) do |s|
+    s.event(1)
+  end
 
   sensors.cpu(Random.rand(100))
 


### PR DESCRIPTION
`rake example:full` failed to start because of `ArgumentError` during the attempt to call `sensors.sensor` without a block. I gave it a block.
