### PR TITLE
Improve main page layout

### DIFF
--- a/lib/pulse-meter/visualize/views/main.haml
+++ b/lib/pulse-meter/visualize/views/main.haml
@@ -20,14 +20,11 @@
     = partial "widgets/#{wtype}"
   = partial "sensors"
 
-  .container#main
-    .row
-      .span10.offset1
-        .navbar
-          .navbar-inner
-            .container
-              %a{href: '#/custom'}
-                %span.brand= @title 
-                %ul.nav#page-titles
-        #widgets.row
+  .navbar.navbar-fixed-top
+    .navbar-inner
+      .container-fluid
+        %a.brand{href: '#/custom'}= @title
+        %ul.nav#page-titles
 
+  .container-fluid#main
+    .row-fluid#widgets


### PR DESCRIPTION
Before:
![before](https://f.cloud.github.com/assets/252023/639758/e30195ca-d2db-11e2-8fb0-a4f7c7d2a77a.png)

After:
![after](https://f.cloud.github.com/assets/252023/639768/4d68ba74-d2dc-11e2-80bc-7f896828da75.png)

Fluid layout allows you to put MOAR GRAPHZ per row (very useful for Full-HD monitors) by setting a smaller widget width (2-3), yet they will still be wide enough. On smaller monitors, extra widgets will be wrapped.

The graphs on the second picture don't take up all the width because their widths are set to 5 and the total number of columns is 12.
